### PR TITLE
Removed census_extra_calibration_group key-value pair from config_dev

### DIFF
--- a/cons_results/configs/config_dev.json
+++ b/cons_results/configs/config_dev.json
@@ -95,15 +95,13 @@
     ],
     "sample_keep_columns": ["reference", "period"],
 
-    "census_extra_calibration_group": [5043, 5113, 5123, 5203, 5233,
-     5403, 5643, 5763, 5783, 5903, 6073],
-     "filter_out_questions": [11, 12 ,146],
-     "csw_to_spp_columns":{
+    "filter_out_questions": [11, 12 ,146],
+    "csw_to_spp_columns":{
         "returned_value":"response",
         "adjusted_value":"adjustedresponse",
         "question_no":"questioncode"
-     },
-     "type_to_imputation_marker" : {
+    },
+    "type_to_imputation_marker" : {
         "0":"selected, no return",
         "1":"r",
         "2":"derived",
@@ -115,9 +113,9 @@
         "11":"r",
         "12":"derived",
         "13":"fir"
-        },
-  "additional_outputs":[],
-  "all_questions":[201,202,211,212,221,222,231,232,241,242,243],
+    },
+    "additional_outputs":[],
+    "all_questions":[201,202,211,212,221,222,231,232,241,242,243],
 
 "bands" : {
     "0": [1,7],


### PR DESCRIPTION
# Changing census grouping

Changing the config to remove the census extra grouping as it is not required for construction

# Summary

Add your summary here - keep it brief, to the point, and in plain English.

# Type of Change

<!--
Please select the type of change that applies to this pull request.
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

## Creator Checklist

- [ ] Installable with all dependencies recorded
- [ ] Runs without error
- [ ] Follows PEP8 and project-specific conventions
- [ ] Appropriate use of comments, for example, no descriptive comments
- [ ] Functions documented using Numpy style docstrings
- [ ] Assumptions and decisions log considered and updated if appropriate
- [ ] Unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [ ] Other forms of testing such as end-to-end and user-interface testing have been considered and updated as required

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.

## Reviewer Checklist

- [ ] Test suite passes (locally as a minimum)
- [ ] Peer reviewed with review recorded

# Additional Information

Please provide any additional information or context that would help the reviewer understand the changes in this pull request.

# Related Issues

Link any related issues or pull requests here.
