### PR TITLE
add convert_nil_marker into construction staging

### DIFF
--- a/cons_results/configs/config_dev.json
+++ b/cons_results/configs/config_dev.json
@@ -25,6 +25,7 @@
     "imputation_class": "imputation_class",
     "l_value_question_no": "questioncode",
     "froempment": "froempment",
+    "nil_status_col": "status",
 
     "master_column_type_dict" : {
         "reference": "int",
@@ -144,6 +145,9 @@
         "42220", "42900", "42910", "42990", "43100", "43110", "43120", "43130",
         "43210", "43220", "43290", "43310", "43320", "43330", "43340", "43341",
         "43342", "43390", "43910", "43990", "43991", "43999"
-    ]
+    ],
 
+    "nil_values" : ["Combined child (NIL2)", "Out of scope (NIL3)", "Ceased trading (NIL4)" ,"Dormant (NIL5)",
+    "Part year return (NIL8)",
+    "No UK activity (NIL9)"]
 }

--- a/cons_results/staging/stage_dataframe.py
+++ b/cons_results/staging/stage_dataframe.py
@@ -4,6 +4,7 @@ import pandas as pd
 from mbs_results.staging.back_data import append_back_data
 from mbs_results.staging.data_cleaning import (
     convert_annual_thousands,
+    convert_nil_values,
     enforce_datatypes,
     filter_out_questions,
     run_live_or_frozen,
@@ -135,6 +136,9 @@ def stage_dataframe(config: dict) -> pd.DataFrame:
 
     print("Staging Completed")
 
+    df = convert_nil_values(
+        df, config["nil_status_col"], config["target"], config["nil_values"]
+    )
     return df, manual_constructions, filter_df
 
 


### PR DESCRIPTION
# Pull Request Title

<!--
Please provide a descriptive title for the pull request.
-->

# Summary

Added code to import and use convert_nil_values in staging dataframe 
Unit tests have not been created as this is extensively tested in mbs package

# Type of Change

<!--
Please select the type of change that applies to this pull request.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

## Creator Checklist

- [x] Installable with all dependencies recorded
- [x] Runs without error
- [x] Follows PEP8 and project-specific conventions
- [x] Appropriate use of comments, for example, no descriptive comments
- [x] Functions documented using Numpy style docstrings
- [x] Assumptions and decisions log considered and updated if appropriate
- [x] Unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] Other forms of testing such as end-to-end and user-interface testing have been considered and updated as required

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.

## Reviewer Checklist

- [ ] Test suite passes (locally as a minimum)
- [ ] Peer reviewed with review recorded

# Additional Information

Please provide any additional information or context that would help the reviewer understand the changes in this pull request.

# Related Issues

Link any related issues or pull requests here.
